### PR TITLE
Update resconstruction script instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
-=========
-2-BM Docs
-=========
+32-ID Docs
+==========
 
 
 `32-ID Docs <https://32id-docs.readthedocs.io>`_ provides instruction and troubleshoting information to operate the APS beamline 32-ID

--- a/docs/source/manual/item_004.rst
+++ b/docs/source/manual/item_004.rst
@@ -6,19 +6,19 @@ At the APS
 
 Your raw data are automatically copied from the detector to the analysis computer (handyn in this example) under the folder /local/data/YYYY-MM/PI_lastName. After the transfer the data are also automatically reconstructed with:: 
 
-    recon --type try --srs 30  /local/data/YYYY-MM/PI_lastName/file.h5 
+    [tomo@handyn,~]$ tomopy recon --reconstruction-type try --hdf-file /local/data.h5
 
 
 Login at the beamline Linux machine handyn as user “tomo” then type::
 
-    [tomo@handyn,~]$ recon -h
+    [tomo@handyn,~]$ tomopy recon -h
 
 
-for help. More detailed instruction are at https://github.com/decarlof/util/tree/master/recon
+for help. More detailed instruction are at https://github.com/tomography/tomopy-cli
 
 To do a test reconstruction just type::
 
-    tomo@handyn,~]$ recon /local/data/YYYY-MM/PI_lastName/file.h5 
+    [tomo@handyn,~]$ tomopy recon --hdf-file /local/data/YYYY-MM/PI_lastName/file.h5 
 
 
 At your home institution
@@ -27,9 +27,13 @@ At your home institution
 Install the following::
 
     Conda: https://www.anaconda.com/download/
-    Tomopy: conda install -c conda-forge tomopy
+    tomopy: conda install -c conda-forge tomopy
+    tomopy-cli: https://github.com/tomography/tomopy-cli
 
-then copy from https://github.com/decarlof/util/tree/master/recon in your python working directory::
+then you can run reconstrutions with::
 
-    find_center
-    recon
+    $ tomopy recon --hdf-file /data/file.h5
+
+or find the rotation axis for all datasets in /data with::
+
+    $ tomopy find_center --hdf-file /data/


### PR DESCRIPTION
Update to use the new tomopy-cli. The new page will look like [this](https://2bm-ops.readthedocs.io/en/latest/source/manual/item_004.html).